### PR TITLE
add Ruby 3.2, 3.1 to the list of tested Rubies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: [3.0, 2.7, 2.6, 2.5]
+        ruby: [3.2, 3.1, 3.0, 2.7, 2.6, 2.5]
 
     steps:
     - uses: actions/checkout@v2

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bundler'
 require 'command_line'
 require 'command_line_tests'
 require 'command_line_bang_tests'


### PR DESCRIPTION
Getting specs passing, bundler need to be required. Don't know if that's a new Rubygems thing or not.